### PR TITLE
Fix regex escape in zabbix.py

### DIFF
--- a/plugins/httpapi/zabbix.py
+++ b/plugins/httpapi/zabbix.py
@@ -141,7 +141,7 @@ class HttpApi(HttpApiBase):
         }
 
         if self.connection._auth:
-            if hasattr(self.connection, 'zbx_api_version') and re.match('^7\..*$', self.connection.zbx_api_version):
+            if hasattr(self.connection, 'zbx_api_version') and re.match('^7\\..*$', self.connection.zbx_api_version):
                 hdrs['Authorization'] = ('Bearer %s' % (self.connection._auth['auth']))
             else:
                 data['auth'] = self.connection._auth['auth']


### PR DESCRIPTION
Python 3.13.0

error was:
```
path/to/.ansible/collections/ansible_collections/community/zabbix/plugins/httpapi/zabbix.py:144: SyntaxWarning: invalid escape sequence '\.'
  if hasattr(self.connection, 'zbx_api_version') and re.match('^7\..*$', self.connection.zbx_api_version):
```